### PR TITLE
[ci] Bump Node.js to 24 in GitHub workflows

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -22,7 +22,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [20.x]
+                node-version: [24.x]
 
         steps:
             - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [20.x]
+                node-version: [24.x]
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [20.x]
+                node-version: [24.x]
 
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Bump `node-version` from 20.x to 24.x in the unit-test workflow and both jobs of the production deploy workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)